### PR TITLE
Fix exception repr() in Python 3

### DIFF
--- a/betamax/exceptions.py
+++ b/betamax/exceptions.py
@@ -3,7 +3,7 @@ class BetamaxError(Exception):
         super(BetamaxError, self).__init__(message)
 
     def __repr__(self):
-        return 'BetamaxError("%s")' % self.message
+        return 'BetamaxError("%s")' % (self,)
 
 
 class MissingDirectoryError(BetamaxError):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -33,3 +33,7 @@ class TestExceptions(unittest.TestCase):
     def test_invalid_option_is_validation_error(self):
         assert isinstance(exceptions.InvalidOption('msg'),
                           exceptions.ValidationError)
+
+    def test_all_exceptions_are_repr_able(self):
+        for exception_class in exception_classes():
+            assert repr(exception_class('msg')) == 'BetamaxError("msg")'


### PR DESCRIPTION
Exceptions in Python 3 don't have a `message` attribute, and so calling `repr()` on a `BetamaxError` in Python 3 fails.  This patch fixes that.
