### PR TITLE
Tests: Remove X-Processed-Time header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       env: TOXENV=py34 REQUESTS_VERSION="===2.2.1"
     - python: 3.5
       env: TOXENV=py35 REQUESTS_VERSION="===2.2.1"
+    - python: 3.6
+      env: TOXENV=py36 REQUESTS_VERSION="===2.2.1"
+    - python: pypy
+      env: TOXENV=pypy REQUESTS_VERSION="===2.2.1"
     - env: TOXENV=py27-flake8
     - env: TOXENV=py34-flake8
     - env: TOXENV=docstrings

--- a/tests/integration/test_record_modes.py
+++ b/tests/integration/test_record_modes.py
@@ -29,12 +29,16 @@ class TestRecordOnce(IntegrationHelper):
             r0_headers = r0.headers.copy()
             r0_headers.pop('Date')
             r0_headers.pop('Age', None)
+            r0_headers.pop('X-Processed-Time', None)
             r1_headers = r1.headers.copy()
             r1_headers.pop('Date')
             r1_headers.pop('Age', None)
+            r1_headers.pop('X-Processed-Time', None)
             # NOTE(sigmavirus24): This fails if the second request is
             # technically a second later. Ignoring the Date headers allows
             # this test to succeed.
+            # NOTE(hroncok): httpbin.org added X-Processed-Time header that
+            # can possibly differ (and often does)
             assert r0_headers == r1_headers
             assert r0.content == r1.content
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,{py27,py34}-flake8,docstrings
+envlist = py27,py33,py34,py35,py36,pypy,{py27,py34}-flake8,docstrings
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
httpbin.org added X-Processed-Time header that can possibly differ (and often does), so we need to get rid of it like the Date header.

Other projects noticed this as well, see libwww-perl/Net-HTTP#48

Fixes #146