### PR TITLE
Add support for binary serializer storage

### DIFF
--- a/docs/source/serializers.rst
+++ b/docs/source/serializers.rst
@@ -25,6 +25,13 @@ implement three methods:
 - :py:meth:`betamax.BaseSerializer.deserialize` is a method that takes a 
   string and returns the data serialized in it as a dictionary.
 
+.. versionadded:: 0.9.0
+
+    Allow Serializers to indicate their format is a binary format via
+    ``stored_as_binary``.
+
+Additionally, if your Serializer is utilizing a binary format, you will want
+to set the ``stored_as_binary`` attribute to ``True`` on your class.
 
 .. autoclass:: betamax.BaseSerializer
     :members:

--- a/src/betamax/serializers/base.py
+++ b/src/betamax/serializers/base.py
@@ -4,7 +4,6 @@ NOT_IMPLEMENTED_ERROR_MSG = ('This method must be implemented by classes'
 
 
 class BaseSerializer(object):
-
     """
     Base Serializer class that provides an interface for other serializers.
 
@@ -37,6 +36,7 @@ class BaseSerializer(object):
     """
 
     name = None
+    stored_as_binary = False
 
     @staticmethod
     def generate_cassette_name(cassette_library_dir, cassette_name):

--- a/src/betamax/serializers/json_serializer.py
+++ b/src/betamax/serializers/json_serializer.py
@@ -7,6 +7,7 @@ import os
 class JSONSerializer(BaseSerializer):
     # Serializes and deserializes a cassette to JSON
     name = 'json'
+    stored_as_binary = False
 
     @staticmethod
     def generate_cassette_name(cassette_library_dir, cassette_name):

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -1,42 +1,110 @@
+"""Tests for serializers."""
 import os
-import pytest
 import unittest
 
-from betamax.serializers import BaseSerializer, JSONSerializer
+import mock
+import pytest
+
+from betamax.serializers import base
+from betamax.serializers import json_serializer
+from betamax.serializers import proxy
 
 
 class TestJSONSerializer(unittest.TestCase):
+    """Tests around the JSONSerializer default."""
+
     def setUp(self):
+        """Fixture setup."""
         self.cassette_dir = 'fake_dir'
         self.cassette_name = 'cassette_name'
 
     def test_generate_cassette_name(self):
+        """Verify the beaviour of generate_cassette_name."""
         assert (os.path.join('fake_dir', 'cassette_name.json') ==
-                JSONSerializer.generate_cassette_name(self.cassette_dir,
-                                                      self.cassette_name))
+                json_serializer.JSONSerializer.generate_cassette_name(
+                    self.cassette_dir,
+                    self.cassette_name,
+                ))
 
     def test_generate_cassette_name_with_instance(self):
-        serializer = JSONSerializer()
+        """Verify generate_cassette_name works on an instance too."""
+        serializer = json_serializer.JSONSerializer()
         assert (os.path.join('fake_dir', 'cassette_name.json') ==
                 serializer.generate_cassette_name(self.cassette_dir,
                                                   self.cassette_name))
 
 
-class Serializer(BaseSerializer):
+class Serializer(base.BaseSerializer):
+    """Serializer to test NotImplementedError exceptions."""
+
     name = 'test'
 
 
+class BytesSerializer(base.BaseSerializer):
+    """Serializer to test stored_as_binary."""
+
+    name = 'bytes-test'
+    stored_as_binary = True
+
+    # NOTE(sigmavirus24): These bytes, when decoded, result in a
+    # UnicodeDecodeError
+    serialized_bytes = b"hi \xAD"
+
+    def serialize(self, *args):
+        """Return the problematic bytes."""
+        return self.serialized_bytes
+
+    def deserialize(self, *args):
+        """Return the problematic bytes."""
+        return self.serialized_bytes
+
+
 class TestBaseSerializer(unittest.TestCase):
+    """Tests around BaseSerializer behaviour."""
+
     def test_serialize_is_an_interface(self):
+        """Verify we handle unimplemented methods."""
         serializer = Serializer()
         with pytest.raises(NotImplementedError):
             serializer.serialize({})
 
     def test_deserialize_is_an_interface(self):
+        """Verify we handle unimplemented methods."""
         serializer = Serializer()
         with pytest.raises(NotImplementedError):
             serializer.deserialize('path')
 
     def test_requires_a_name(self):
+        """Verify we handle unimplemented methods."""
         with pytest.raises(ValueError):
-            BaseSerializer()
+            base.BaseSerializer()
+
+
+class TestBinarySerializers(unittest.TestCase):
+    """Verify the behaviour of stored_as_binary."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        serializer = BytesSerializer()
+        self.cassette_path = 'test_cassette.test'
+        self.proxy = proxy.SerializerProxy(
+            serializer,
+            self.cassette_path,
+            allow_serialization=True,
+        )
+
+    def test_serialize(self):
+        """Verify we use the right mode with open()."""
+        mopen = mock.mock_open()
+        with mock.patch('betamax.serializers.proxy.open', mopen):
+            self.proxy.serialize({'cassette': 'data'})
+
+        assert mock.call(self.cassette_path, 'wb') in mopen.mock_calls
+
+    def test_deserialize(self):
+        """Verify we use the right mode with open()."""
+        mopen = mock.mock_open()
+        with mock.patch('betamax.serializers.proxy.open', mopen):
+            self.proxy.deserialize()
+
+        assert mock.call(self.cassette_path, 'rb') in mopen.mock_calls

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -2,7 +2,6 @@
 import os
 import unittest
 
-import mock
 import pytest
 
 from betamax.serializers import base
@@ -81,7 +80,7 @@ class TestBaseSerializer(unittest.TestCase):
 
 
 class TestBinarySerializers(unittest.TestCase):
-    """Verify the behaviour of stored_as_binary."""
+    """Verify the behaviour of stored_as_binary=True."""
 
     @pytest.fixture(autouse=True)
     def _setup(self):
@@ -95,16 +94,34 @@ class TestBinarySerializers(unittest.TestCase):
 
     def test_serialize(self):
         """Verify we use the right mode with open()."""
-        mopen = mock.mock_open()
-        with mock.patch('betamax.serializers.proxy.open', mopen):
-            self.proxy.serialize({'cassette': 'data'})
-
-        assert mock.call(self.cassette_path, 'wb') in mopen.mock_calls
+        mode = self.proxy.corrected_file_mode('w')
+        assert mode == 'wb'
 
     def test_deserialize(self):
         """Verify we use the right mode with open()."""
-        mopen = mock.mock_open()
-        with mock.patch('betamax.serializers.proxy.open', mopen):
-            self.proxy.deserialize()
+        mode = self.proxy.corrected_file_mode('r')
+        assert mode == 'rb'
 
-        assert mock.call(self.cassette_path, 'rb') in mopen.mock_calls
+
+class TestTextSerializer(unittest.TestCase):
+    """Verify the default behaviour of stored_as_binary."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        serializer = Serializer()
+        self.cassette_path = 'test_cassette.test'
+        self.proxy = proxy.SerializerProxy(
+            serializer,
+            self.cassette_path,
+            allow_serialization=True,
+        )
+
+    def test_serialize(self):
+        """Verify we use the right mode with open()."""
+        mode = self.proxy.corrected_file_mode('w')
+        assert mode == 'w'
+
+    def test_deserialize(self):
+        """Verify we use the right mode with open()."""
+        mode = self.proxy.corrected_file_mode('r')
+        assert mode == 'r'

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,7 @@ pip_pre = False
 deps =
     requests{env:REQUESTS_VERSION: >= 2.0}
     pytest
-    pypy: mock
-    py26: mock < 1.1.0
-    py27: mock
-    py32: mock
-    py33: mock
+    mock
 commands = py.test {posargs}
 
 [testenv:py27-flake8]


### PR DESCRIPTION
Some serializers return bytes instead of text and we need a way to
indicate that when opening the cassette file.

Related-to gh-123

--- 

cc @wimglenn for review