### PR TITLE
Fix bug with new_episodes always trying to record

### DIFF
--- a/src/betamax/cassette/cassette.py
+++ b/src/betamax/cassette/cassette.py
@@ -119,8 +119,11 @@ class Cassette(object):
         :returns: :class:`~betamax.cassette.Interaction`
         """
         # if we are recording, do not filter by match
-        if self.is_recording() and self.record_mode != 'all':
-            return None
+        if self.is_recording():
+            if ((self.record_mode == 'new_episodes' and
+                 all(i.used is True for i in self.interactions)) or
+                    self.record_mode in ('once', 'none')):
+                return None
 
         opts = self.match_options
         # Curry those matchers

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -312,6 +312,28 @@ class TestCassette(unittest.TestCase):
         assert i is not None
         assert self.interaction is i
 
+    def test_find_match_new_episodes_with_existing_unused_interactions(self):
+        """See bug 153 in GitHub for details.
+
+        https://github.com/betamaxpy/betamax/issues/153
+        """
+        self.cassette.match_options = set(['method', 'uri'])
+        self.cassette.record_mode = 'new_episodes'
+        i = self.cassette.find_match(self.response.request)
+        assert i is not None
+        assert self.interaction is i
+
+    def test_find_match_new_episodes_with_no_unused_interactions(self):
+        """See bug 153 in GitHub for details.
+
+        https://github.com/betamaxpy/betamax/issues/153
+        """
+        self.cassette.match_options = set(['method', 'uri'])
+        self.cassette.record_mode = 'new_episodes'
+        self.interaction.used = True
+        i = self.cassette.find_match(self.response.request)
+        assert i is None
+
     def test_find_match__missing_matcher(self):
         self.cassette.match_options = set(['uri', 'method', 'invalid'])
         self.cassette.record_mode = 'none'


### PR DESCRIPTION
This enables new_episodes to return the previously recorded interactions
first and then record new ones if necessary.

Closes gh-153