### PR TITLE
Make docstrings required and remove Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,12 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 2.7
       env: TOXENV=py27 REQUESTS_VERSION="===2.2.1"
-    - python: 3.3
-      env: TOXENV=py33 REQUESTS_VERSION="===2.2.1"
     - python: 3.4
       env: TOXENV=py34 REQUESTS_VERSION="===2.2.1"
     - python: 3.5
@@ -38,5 +34,3 @@ matrix:
     - env: TOXENV=docstrings
     - env: TOXENV=docs
     - env: TOXENV=readme
-  allow_failures:
-  - env: TOXENV=docstrings


### PR DESCRIPTION
Python 3.3 reached EOL a while back and now no longer works with our deps