### PR TITLE
Add shortcircuit condition if text_to_replace is a blank string

### DIFF
--- a/src/betamax/cassette/interaction.py
+++ b/src/betamax/cassette/interaction.py
@@ -69,6 +69,8 @@ class Interaction(object):
             self.replace(*placeholder.unpack(serializing))
 
     def replace_in_headers(self, text_to_replace, placeholder):
+        if text_to_replace == '':
+            return
         for obj in ('request', 'response'):
             headers = self.data[obj]['headers']
             for k, v in list(headers.items()):
@@ -79,6 +81,8 @@ class Interaction(object):
                     headers[k] = v.replace(text_to_replace, placeholder)
 
     def replace_in_body(self, text_to_replace, placeholder):
+        if text_to_replace == '':
+            return
         for obj in ('request', 'response'):
             body = self.data[obj]['body']
             old_style = hasattr(body, 'replace')
@@ -93,6 +97,8 @@ class Interaction(object):
                 self.data[obj]['body']['string'] = body
 
     def replace_in_uri(self, text_to_replace, placeholder):
+        if text_to_replace == '':
+            return
         for (obj, key) in (('request', 'uri'), ('response', 'url')):
             uri = self.data[obj][key]
             if text_to_replace in uri:

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -443,6 +443,7 @@ class TestInteraction(unittest.TestCase):
         self.interaction.replace('secret_value', '<SECRET_VALUE>')
         self.interaction.replace('foo', '<FOO>')
         self.interaction.replace('http://example.com', '<EXAMPLE_URI>')
+        self.interaction.replace('', '<IF_FAIL_THIS_INSERTS_BEFORE_AND_AFTER_EACH_CHARACTER')
 
         header = (
             self.interaction.data['request']['headers']['Authorization'][0])


### PR DESCRIPTION
This is to fix #169.

I couldn't think of a better way to test this than to add an additional `.replace` to the `test_replace` test case and if this code doesn't exist, it would alter interaction strings.