### PR TITLE
Minor doc fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -240,6 +240,6 @@ texinfo_appendices = []
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6',
                (None, 'python-inv.txt')),
-    'requests': ('http://docs.python-requests.org/en/latest',
+    'requests': ('https://requests.readthedocs.io/en/latest',
                  (None, 'requests-inv.txt')),
 }

--- a/src/betamax/decorator.py
+++ b/src/betamax/decorator.py
@@ -8,7 +8,7 @@ from . import recorder
 
 def use_cassette(cassette_name, cassette_library_dir=None,
                  default_cassette_options={}, **use_cassette_kwargs):
-    """Provide a Betamax-wrapped Session for convenience.
+    r"""Provide a Betamax-wrapped Session for convenience.
 
     .. versionadded:: 0.5.0
 


### PR DESCRIPTION
Old requests autodoc URL currently redirects to https://2.python-requests.org//en/latest - which isn't configured correctly for SSL. https://github.com/psf/requests/pull/5236 changed the official documentation URL also.

And the decorators.py tweak fixes:

```
<unknown>:35: DeprecationWarning: invalid escape sequence \*
```

Which is deprecated as of Python 3.6: https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior