### PR TITLE
Add cassette_load and cassette_eject hooks

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors
 - Marc Abramowitz (@msabramo)
 - Bryce Boe <bbzbryce@gmail.com> (@bboe)
 - Alex Richard-Hoyling <@arhoyling)
+- Joey RH <jarhill0@gmail.com> (@jarhill0)

--- a/docs/source/configuring.rst
+++ b/docs/source/configuring.rst
@@ -241,6 +241,27 @@ have our hook, we need merely register it like so:
 
 And we no longer need to worry about leaking sensitive data.
 
+In addition to the ``before_record`` and ``before_playback`` hooks,
+version 0.9.0 of Betamax adds :meth:`.after_start` and :meth:`.before_stop`
+hooks. These two hooks both will pass the current
+:class:`~betamax.cassette.cassette.Cassette` to the callback function provided.
+Register these hooks like so:
+
+.. code-block:: python
+
+    def hook(cassette):
+        if cassette.is_recording():
+            print("This cassette is recording!")
+
+    # Either
+    config.after_start(callback=hook)
+    # Or
+    config.before_stop(callback=hook)
+
+These hooks are useful for performing configuration actions external to Betamax
+at the time Betamax is invoked, such as setting up correct authentication to
+an API so that the recording will not encounter any errors.
+
 
 Setting default serializer
 ``````````````````````````

--- a/src/betamax/recorder.py
+++ b/src/betamax/recorder.py
@@ -123,10 +123,13 @@ class Betamax(object):
         """Start recording or replaying interactions."""
         for k in self.http_adapters:
             self.session.mount(k, self.betamax_adapter)
+        dispatch_hooks('after_start', self.betamax_adapter.cassette)
 
     # ■
     def stop(self):
         """Stop recording or replaying interactions."""
+        dispatch_hooks('before_stop', self.betamax_adapter.cassette)
+
         # No need to keep the cassette in memory any longer.
         self.betamax_adapter.eject_cassette()
         # On exit, we no longer wish to use our adapter and we want the
@@ -166,3 +169,10 @@ class Betamax(object):
             raise ValueError('Cassette must have a valid name and may not be'
                              ' None.')
         return self
+
+
+def dispatch_hooks(hook_name, *args):
+    """Dispatch registered hooks."""
+    hooks = Configuration.recording_hooks[hook_name]
+    for hook in hooks:
+        hook(*args)

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -17,12 +17,60 @@ def preplayback_hook(interaction, cassette):
     interaction.data['response']['headers']['Betamax-Fake-Header'] = 'temp'
 
 
+class Counter(object):
+    def __init__(self):
+        self.value = 0
+
+    def increment(self, cassette):
+        self.value += 1
+
+
 class TestHooks(helper.IntegrationHelper):
     def tearDown(self):
         super(TestHooks, self).tearDown()
         # Clear out the hooks
+        betamax.configure.Configuration.recording_hooks.pop('after_start', None)
         betamax.cassette.Cassette.hooks.pop('before_record', None)
         betamax.cassette.Cassette.hooks.pop('before_playback', None)
+        betamax.configure.Configuration.recording_hooks.pop('before_stop', None)
+
+    def test_post_start_hook(self):
+        start_count = Counter()
+        with betamax.Betamax.configure() as config:
+            config.after_start(callback=start_count.increment)
+
+        recorder = betamax.Betamax(self.session)
+
+        assert start_count.value == 0
+        with recorder.use_cassette('after_start_hook'):
+            assert start_count.value == 1
+            self.cassette_path = recorder.current_cassette.cassette_path
+            self.session.get('https://httpbin.org/get')
+
+        assert start_count.value == 1
+        with recorder.use_cassette('after_start_hook', record='none'):
+            assert start_count.value == 2
+            self.session.get('https://httpbin.org/get')
+        assert start_count.value == 2
+
+    def test_pre_stop_hook(self):
+        stop_count = Counter()
+        with betamax.Betamax.configure() as config:
+            config.before_stop(callback=stop_count.increment)
+
+        recorder = betamax.Betamax(self.session)
+
+        assert stop_count.value == 0
+        with recorder.use_cassette('before_stop_hook'):
+            self.cassette_path = recorder.current_cassette.cassette_path
+            self.session.get('https://httpbin.org/get')
+            assert stop_count.value == 0
+        assert stop_count.value == 1
+
+        with recorder.use_cassette('before_stop_hook', record='none'):
+            self.session.get('https://httpbin.org/get')
+            assert stop_count.value == 1
+        assert stop_count.value == 2
 
     def test_prerecord_hook(self):
         with betamax.Betamax.configure() as config:


### PR DESCRIPTION
Fixes #178.

This PR adds two new hooks: `cassette_load` and `cassette_eject`. They are called when a cassette is first loaded or when it is ejected, respectively. [Here's a demonstration of the hooks in use along with the corresponding output](https://gist.github.com/jarhill0/72dd9e43d29f2b47d846edc263a0a7f2).

I've also added a little section to the documentation about the new hooks in which I guess that these hooks will be first released with Betamax 0.9.0, which may or may not need to be corrected.