### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/serializers.rst
+++ b/docs/source/serializers.rst
@@ -19,7 +19,7 @@ implement three methods:
   This will take the directory the user (you) wants to store the cassettes in 
   and the name of the cassette and generate the file name.
 
-- :py:meth:`betamax.BaseSerializer.seralize` is a method that takes the 
+- :py:meth:`betamax.BaseSerializer.serialize` is a method that takes the 
   dictionary and returns the dictionary serialized as a string
 
 - :py:meth:`betamax.BaseSerializer.deserialize` is a method that takes a 

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -18,7 +18,7 @@ class TestJSONSerializer(unittest.TestCase):
         self.cassette_name = 'cassette_name'
 
     def test_generate_cassette_name(self):
-        """Verify the beaviour of generate_cassette_name."""
+        """Verify the behaviour of generate_cassette_name."""
         assert (os.path.join('fake_dir', 'cassette_name.json') ==
                 json_serializer.JSONSerializer.generate_cassette_name(
                     self.cassette_dir,


### PR DESCRIPTION
There are small typos in:
- docs/source/serializers.rst
- tests/unit/test_serializers.py

Fixes:
- Should read `serialize` rather than `seralize`.
- Should read `behaviour` rather than `beaviour`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md