### PR TITLE
Update supported python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,13 +5,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [py37-flake8, py37-docstrings]
+        job: [py38-flake8, py38-docstrings]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: pip install --upgrade pip
       - run: pip install tox
       - run: tox -e ${{ matrix.job }}
@@ -22,7 +22,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
+        python: ['3.8', '3.9', '3.10', '3.11', 'pypy3.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,37 +13,26 @@ notifications:
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.6
-      env: TOXENV=py36
-    - python: 3.7
-      env: TOXENV=py37
-      dist: xenial
-      sudo: required  # needed for 3.7
-    - python: 2.7
-      env: TOXENV=py27 REQUESTS_VERSION="===2.2.1"
-    - python: 3.4
-      env: TOXENV=py34 REQUESTS_VERSION="===2.2.1"
-    - python: 3.5
-      env: TOXENV=py35 REQUESTS_VERSION="===2.2.1"
-    - python: 3.6
-      env: TOXENV=py36 REQUESTS_VERSION="===2.2.1"
-    - python: 3.7
-      env: TOXENV=py37 REQUESTS_VERSION="===2.2.1"
-      dist: xenial
-      sudo: required
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
+    - python: 3.10
+      env: TOXENV=py310
+    - python: 3.11
+      env: TOXENV=py311
+    - python: 3.8
+      env: TOXENV=py38 REQUESTS_VERSION="===2.2.1"
+    - python: 3.9
+      env: TOXENV=py39 REQUESTS_VERSION="===2.2.1"
+    - python: 3.10
+      env: TOXENV=py310 REQUESTS_VERSION="===2.2.1"
+    - python: 3.11
+      env: TOXENV=py311 REQUESTS_VERSION="===2.2.1"
     - python: pypy
       env: TOXENV=pypy REQUESTS_VERSION="===2.2.1"
-    - env: TOXENV=py27-flake8
-    - env: TOXENV=py37-flake8
-      python: 3.7
-      dist: xenial
-      sudo: required
+    - env: TOXENV=py38-flake8
+      python: 3.8
     - env: TOXENV=docstrings
     - env: TOXENV=docs
     - env: TOXENV=readme

--- a/setup.py
+++ b/setup.py
@@ -53,18 +53,17 @@ setuptools.setup(
     entry_points={
         "pytest11": ["pytest-betamax = betamax.fixtures.pytest"]
     },
+    python_requires='>=3.8',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy,{py27,py37}-flake8,docstrings
+envlist = py38,py39,py310,py311,pypy,py38-flake8,docstrings
 
 [testenv]
 pip_pre = False
@@ -9,14 +9,8 @@ deps =
     mock
 commands = py.test {posargs}
 
-[testenv:py27-flake8]
-basepython = python2.7
-deps =
-    flake8
-commands = flake8 {posargs} src/betamax
-
-[testenv:py37-flake8]
-basepython = python3.7
+[testenv:py38-flake8]
+basepython = python3.8
 deps =
     flake8
 commands = flake8 {posargs} src/betamax


### PR DESCRIPTION
The list in the classifiers is quite outdated. This updates the list according to the current tested versions.

Note that python 3.7 is already EOL, so this change removes the test with python 3.7 and explicitly requires >=3.8 .